### PR TITLE
Fix TV shows not being detected as existing in library

### DIFF
--- a/src/api/plex.rs
+++ b/src/api/plex.rs
@@ -142,7 +142,10 @@ impl Plex {
 
         for metadata in meta {
             if !exact_match {
-                if metadata.title.starts_with(title) && metadata.year.eq(&year) {
+                if (
+                    metadata.title.starts_with(title)
+                        || metadata.original_title.starts_with(title)
+                ) && metadata.year.eq(&year) {
                     match metadata.media.first() {
                         Some(t) => match t.part.first() {
                             Some(p) => {
@@ -237,7 +240,10 @@ impl Plex {
         };
 
         for metadata in shows_hub {
-            if metadata.title.starts_with(title) && metadata.year.eq(&year) {
+            if (
+                metadata.title.starts_with(title) 
+                || metadata.original_title.starts_with(title)
+            ) && metadata.year.eq(&year) {
                 let available = self
                     .fetch_available_tvshow_children(&metadata.rating_key)
                     .await?;
@@ -316,6 +322,7 @@ struct Hub {
 #[derive(Default, Debug, Clone, PartialEq, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 struct PlexLibraryMetadata {
+    original_title: String,
     title: String,
     #[serde(default)]
     year: u32,

--- a/src/api/plex.rs
+++ b/src/api/plex.rs
@@ -142,10 +142,13 @@ impl Plex {
 
         for metadata in meta {
             if !exact_match {
-                if (
-                    metadata.title.starts_with(title)
-                        || metadata.original_title.starts_with(title)
-                ) && metadata.year.eq(&year) {
+                if (metadata.title.starts_with(title)
+                    || match &metadata.original_title {
+                        Some(original_title) => original_title.starts_with(title),
+                        None => false,
+                    })
+                    && metadata.year.eq(&year)
+                {
                     match metadata.media.first() {
                         Some(t) => match t.part.first() {
                             Some(p) => {
@@ -240,10 +243,13 @@ impl Plex {
         };
 
         for metadata in shows_hub {
-            if (
-                metadata.title.starts_with(title) 
-                || metadata.original_title.starts_with(title)
-            ) && metadata.year.eq(&year) {
+            if (metadata.title.starts_with(title)
+                || match &metadata.original_title {
+                    Some(original_title) => original_title.starts_with(title),
+                    None => false,
+                })
+                && metadata.year.eq(&year)
+            {
                 let available = self
                     .fetch_available_tvshow_children(&metadata.rating_key)
                     .await?;
@@ -322,7 +328,7 @@ struct Hub {
 #[derive(Default, Debug, Clone, PartialEq, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 struct PlexLibraryMetadata {
-    original_title: String,
+    original_title: Option<String>,
     title: String,
     #[serde(default)]
     year: u32,


### PR DESCRIPTION
Added originalTitle field for plex hub search to provide an alternative check to match on incase plex displays an alternative name to what IMDb provides.